### PR TITLE
[codex] Add day night theme toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,34 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500;600;700&family=Instrument+Sans:ital,wght@0,400..800;1,400..800&display=swap"
       rel="stylesheet"
     />
+    <script>
+      (function () {
+        var key = "sbangalore-theme";
+        var saved = localStorage.getItem(key);
+        var theme = saved || (matchMedia("(prefers-color-scheme: dark)").matches ? "night" : "day");
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.style.colorScheme = theme === "night" ? "dark" : "light";
+        window.setTheme = function (next) {
+          document.documentElement.dataset.theme = next;
+          document.documentElement.style.colorScheme = next === "night" ? "dark" : "light";
+          localStorage.setItem(key, next);
+          document.querySelectorAll("[data-theme-toggle]").forEach(function (button) {
+            button.querySelector("[data-theme-toggle-icon]").textContent = next === "night" ? "◐" : "☀";
+            button.querySelector("[data-theme-toggle-label]").textContent = next === "night" ? "Dark" : "Light";
+            button.setAttribute("aria-label", next === "night" ? "Dark theme, switch to light mode" : "Light theme, switch to dark mode");
+            button.setAttribute("aria-pressed", next === "night");
+          });
+        };
+        addEventListener("DOMContentLoaded", function () {
+          window.setTheme(document.documentElement.dataset.theme);
+          document.querySelectorAll("[data-theme-toggle]").forEach(function (button) {
+            button.addEventListener("click", function () {
+              window.setTheme(document.documentElement.dataset.theme === "night" ? "day" : "night");
+            });
+          });
+        });
+      })();
+    </script>
     <style>
       :root {
         --ink: #101411;
@@ -17,6 +45,16 @@
         --card: #ffffff;
         --line: #d9ddd2;
         --signal: #315cff;
+        --social-bg: #ffffff;
+      }
+
+      :root[data-theme="night"] {
+        --ink: #f3f6ee;
+        --muted: #aab4ad;
+        --paper: #0d100f;
+        --card: #171c19;
+        --line: #303832;
+        --signal: #8ea4ff;
       }
 
       * {
@@ -63,11 +101,27 @@
       }
 
       .nav-links a,
+      .theme-toggle,
       .read-more {
         border: 1px solid var(--line);
         border-radius: 999px;
         padding: 9px 13px;
         background: color-mix(in srgb, var(--card) 78%, transparent);
+      }
+
+      .theme-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        color: inherit;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      .theme-toggle-icon {
+        width: 22px;
+        text-align: center;
       }
 
       .nav-links .social-link {
@@ -82,6 +136,10 @@
         width: 18px;
         height: 18px;
         object-fit: contain;
+      }
+
+      .nav-links .social-link {
+        background: var(--social-bg);
       }
 
       .social-link--x img {
@@ -222,6 +280,10 @@
           <a href="{{ site.baseurl }}/markets/?map=finance">Atlas</a>
           <a href="{{ site.baseurl }}/writing/">Writing</a>
           <a href="{{ site.baseurl }}/about/">About</a>
+          <button class="theme-toggle" type="button" data-theme-toggle>
+            <span class="theme-toggle-icon" data-theme-toggle-icon aria-hidden="true">☀</span>
+            <span data-theme-toggle-label>Light</span>
+          </button>
           <a class="social-link" href="https://github.com/sbangalore" aria-label="GitHub">
             <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="" />
           </a>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,34 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500;600;700&family=Instrument+Sans:ital,wght@0,400..800;1,400..800&display=swap"
       rel="stylesheet"
     />
+    <script>
+      (function () {
+        var key = "sbangalore-theme";
+        var saved = localStorage.getItem(key);
+        var theme = saved || (matchMedia("(prefers-color-scheme: dark)").matches ? "night" : "day");
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.style.colorScheme = theme === "night" ? "dark" : "light";
+        window.setTheme = function (next) {
+          document.documentElement.dataset.theme = next;
+          document.documentElement.style.colorScheme = next === "night" ? "dark" : "light";
+          localStorage.setItem(key, next);
+          document.querySelectorAll("[data-theme-toggle]").forEach(function (button) {
+            button.querySelector("[data-theme-toggle-icon]").textContent = next === "night" ? "◐" : "☀";
+            button.querySelector("[data-theme-toggle-label]").textContent = next === "night" ? "Dark" : "Light";
+            button.setAttribute("aria-label", next === "night" ? "Dark theme, switch to light mode" : "Light theme, switch to dark mode");
+            button.setAttribute("aria-pressed", next === "night");
+          });
+        };
+        addEventListener("DOMContentLoaded", function () {
+          window.setTheme(document.documentElement.dataset.theme);
+          document.querySelectorAll("[data-theme-toggle]").forEach(function (button) {
+            button.addEventListener("click", function () {
+              window.setTheme(document.documentElement.dataset.theme === "night" ? "day" : "night");
+            });
+          });
+        });
+      })();
+    </script>
     <style>
       :root {
         color-scheme: light;
@@ -24,6 +52,17 @@
         --line: #d9ddd2;
         --signal: #315cff;
         --green: #0f8b6f;
+        --social-bg: #ffffff;
+      }
+
+      :root[data-theme="night"] {
+        --ink: #f3f6ee;
+        --muted: #aab4ad;
+        --paper: #0d100f;
+        --card: #171c19;
+        --line: #303832;
+        --signal: #8ea4ff;
+        --green: #39c69f;
       }
 
       * {
@@ -73,11 +112,27 @@
       }
 
       .nav-links a,
+      .theme-toggle,
       .button {
         border: 1px solid var(--line);
         border-radius: 999px;
         padding: 9px 13px;
         background: color-mix(in srgb, var(--card) 78%, transparent);
+      }
+
+      .theme-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        color: inherit;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      .theme-toggle-icon {
+        width: 22px;
+        text-align: center;
       }
 
       .nav-links .social-link {
@@ -92,6 +147,10 @@
         width: 18px;
         height: 18px;
         object-fit: contain;
+      }
+
+      .nav-links .social-link {
+        background: var(--social-bg);
       }
 
       .social-link--x img {
@@ -272,6 +331,10 @@
           <a href="/markets/?map=finance">Atlas</a>
           <a href="/writing/">Writing</a>
           <a href="/about/">About</a>
+          <button class="theme-toggle" type="button" data-theme-toggle>
+            <span class="theme-toggle-icon" data-theme-toggle-icon aria-hidden="true">☀</span>
+            <span data-theme-toggle-label>Light</span>
+          </button>
           <a class="social-link" href="https://github.com/sbangalore" aria-label="GitHub">
             <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="" />
           </a>

--- a/markets/index.html
+++ b/markets/index.html
@@ -10,12 +10,46 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500;600;700&family=Instrument+Sans:ital,wght@0,400..800;1,400..800&display=swap"
       rel="stylesheet"
     />
+    <script>
+      (function () {
+        var key = "sbangalore-theme";
+        var saved = localStorage.getItem(key);
+        var theme = saved || (matchMedia("(prefers-color-scheme: dark)").matches ? "night" : "day");
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.style.colorScheme = theme === "night" ? "dark" : "light";
+        window.setTheme = function (next) {
+          document.documentElement.dataset.theme = next;
+          document.documentElement.style.colorScheme = next === "night" ? "dark" : "light";
+          localStorage.setItem(key, next);
+          document.querySelectorAll("[data-theme-toggle]").forEach(function (button) {
+            button.querySelector("[data-theme-toggle-icon]").textContent = next === "night" ? "◐" : "☀";
+            button.querySelector("[data-theme-toggle-label]").textContent = next === "night" ? "Dark" : "Light";
+            button.setAttribute("aria-label", next === "night" ? "Dark theme, switch to light mode" : "Light theme, switch to dark mode");
+            button.setAttribute("aria-pressed", next === "night");
+          });
+        };
+        addEventListener("DOMContentLoaded", function () {
+          window.setTheme(document.documentElement.dataset.theme);
+          document.querySelectorAll("[data-theme-toggle]").forEach(function (button) {
+            button.addEventListener("click", function () {
+              window.setTheme(document.documentElement.dataset.theme === "night" ? "day" : "night");
+            });
+          });
+        });
+      })();
+    </script>
     <link rel="stylesheet" href="./styles.css?v=20260614-research-ledger" />
   </head>
   <body>
     <a class="skip-link" href="#directoryMain">Skip to directory</a>
     <header class="topbar">
-      <a class="brand-link" href="/">Sean Bangalore</a>
+      <div class="brand-row">
+        <a class="brand-link" href="/">Sean Bangalore</a>
+        <button class="theme-toggle" type="button" data-theme-toggle>
+          <span class="theme-toggle-icon" data-theme-toggle-icon aria-hidden="true">☀</span>
+          <span data-theme-toggle-label>Light</span>
+        </button>
+      </div>
       <div class="topbar__copy">
         <p id="mapKicker" class="context-label">AI infrastructure stack</p>
         <h1 id="mapTitle">AI infra map</h1>

--- a/markets/styles.css
+++ b/markets/styles.css
@@ -30,6 +30,25 @@
   font-family: var(--font-sans);
 }
 
+:root[data-theme="night"] {
+  color-scheme: dark;
+  --bg: #0d100f;
+  --bg-quiet: #121714;
+  --surface: #171c19;
+  --surface-raised: #1d2420;
+  --surface-inset: #101511;
+  --rule: #303832;
+  --rule-strong: #465048;
+  --text: #f3f6ee;
+  --text-soft: #aab4ad;
+  --text-faint: #7d8980;
+  --accent: #8ea4ff;
+  --accent-strong: #b9c6ff;
+  --patina: #39c69f;
+  --warning: #d79a4a;
+  --danger: #ff8c82;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -105,8 +124,14 @@ main,
   padding: var(--space-6) 0 var(--space-5);
 }
 
-.brand-link {
+.brand-row {
   grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.brand-link {
   width: fit-content;
   color: var(--text);
   font-weight: 800;
@@ -115,6 +140,29 @@ main,
 
 .brand-link:hover {
   color: var(--accent);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface) 78%, transparent);
+  color: var(--text);
+  padding: var(--space-2) var(--space-3);
+  font-weight: 700;
+}
+
+.theme-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.theme-toggle-icon {
+  width: 22px;
+  text-align: center;
 }
 
 .topbar__side {


### PR DESCRIPTION
## Summary
- Add a persisted day/night theme toggle to the home page, shared Jekyll layout, and Atlas page.
- Match the Octomil-style pill with an icon and current state label: Light or Dark.
- Add dark theme color variables for the main site and Atlas surface.

## Validation
- Ran `git diff --cached --check`.
- Verified locally in the in-app browser on `http://127.0.0.1:8765/markets/?map=finance`: the toggle loaded as Dark, clicked to Light, and updated ARIA state/label correctly.

## Notes
- `jekyll` is not installed in this checkout, so no local Jekyll build was run.
- Unrelated local changes in `index.html` and `markets/data/finance/research_ledger.json` were left out of this PR.
