### PR TITLE
[codex] Bust atlas theme stylesheet cache

### DIFF
--- a/markets/index.html
+++ b/markets/index.html
@@ -38,7 +38,7 @@
         });
       })();
     </script>
-    <link rel="stylesheet" href="./styles.css?v=20260614-research-ledger" />
+    <link rel="stylesheet" href="./styles.css?v=20260618-theme-toggle" />
   </head>
   <body>
     <a class="skip-link" href="#directoryMain">Skip to directory</a>


### PR DESCRIPTION
## Summary
- Bump the Atlas stylesheet cache key so GitHub Pages serves the CSS that matches the new theme-toggle markup.

## Why
The live Atlas page was loading updated HTML but an old cached `markets/styles.css`, which left the `.brand-row` layout unstyled and prevented the dark-mode CSS variables from applying on the page.

## Validation
- Served the hotfix worktree locally on `http://127.0.0.1:8765/markets/?map=finance`.
- Verified `.brand-row` computes to `display: flex` and spans the topbar grid.
- Clicked the theme toggle and verified dark mode changes `--bg` to `#0d100f` and shows `◐ Dark`.
