### PR TITLE
Add reviewed atlas source pipeline

### DIFF
--- a/.atlas/README.md
+++ b/.atlas/README.md
@@ -1,0 +1,11 @@
+# Atlas review inbox
+
+`candidate_inbox.json` is generated evidence for review. It is not loaded by the public Markets atlas and must never be copied into public datasets without checking the underlying source.
+
+Promotion rules:
+
+1. Verify the claim at the linked primary source or paper.
+2. Decide whether it changes an entity, literature signal, market-structure score, or unbuilt opportunity.
+3. Record the source URL and observation date in the public record.
+4. Treat X and other social sources as leads only.
+5. Make public atlas changes in a separate, human-reviewable commit.

--- a/.atlas/candidate_inbox.json
+++ b/.atlas/candidate_inbox.json
@@ -1,0 +1,91 @@
+{
+  "candidate_count": 2,
+  "candidates": [
+    {
+      "authority": "research",
+      "candidate_id": "atlas-9bd6202bed244e0a",
+      "lane": "ai",
+      "matched_terms": [
+        "inference",
+        "edge device"
+      ],
+      "promotion_policy": "corroborate",
+      "proposed_targets": [
+        "entries",
+        "literature",
+        "market_structure",
+        "unbuilt"
+      ],
+      "published_at": "2026-07-10T04:00:00+00:00",
+      "review_status": "unreviewed",
+      "source_class": "research_index",
+      "source_id": "openalex-ai",
+      "source_name": "OpenAlex: AI systems research",
+      "title": "DynamiGraph: A Specialized, Runtime-Aware FPGA Overlay for Ultra Low-Latency GNN Inference on Edge Devices",
+      "url": "https://doi.org/10.3390/mi17070824"
+    },
+    {
+      "authority": "research",
+      "candidate_id": "atlas-6ed0d808c1f09242",
+      "lane": "ai",
+      "matched_terms": [
+        "serving",
+        "agent"
+      ],
+      "promotion_policy": "corroborate",
+      "proposed_targets": [
+        "entries",
+        "literature",
+        "market_structure",
+        "unbuilt"
+      ],
+      "published_at": "2026-07-09T04:00:00+00:00",
+      "review_status": "unreviewed",
+      "source_class": "research_index",
+      "source_id": "openalex-ai",
+      "source_name": "OpenAlex: AI systems research",
+      "title": "SMetric: Rethink LLM Scheduling for Serving Agents with Balanced Session-centric Scheduling",
+      "url": "https://arxiv.org/abs/2607.08565"
+    }
+  ],
+  "generated_at": "2026-07-15T05:26:57.972083+00:00",
+  "publication_rule": "Collectors create evidence candidates only. Public atlas claims require review and a separate commit.",
+  "schema_version": 1,
+  "source_runs": [
+    {
+      "candidate_count": 2,
+      "source_id": "openalex-ai",
+      "status": "ok"
+    },
+    {
+      "candidate_count": 0,
+      "source_id": "openalex-finance",
+      "status": "ok"
+    },
+    {
+      "candidate_count": 0,
+      "source_id": "sec-press-releases",
+      "status": "ok"
+    },
+    {
+      "candidate_count": 0,
+      "source_id": "cftc-press-releases",
+      "status": "ok"
+    },
+    {
+      "candidate_count": 0,
+      "source_id": "github-llama-cpp",
+      "status": "ok"
+    },
+    {
+      "candidate_count": 0,
+      "source_id": "github-onnx-runtime",
+      "status": "ok"
+    },
+    {
+      "candidate_count": 0,
+      "source_id": "x-curated-portfolios",
+      "status": "external"
+    }
+  ]
+}

--- a/.github/workflows/atlas-source-refresh.yml
+++ b/.github/workflows/atlas-source-refresh.yml
@@ -1,0 +1,52 @@
+name: Atlas source refresh
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 13 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: atlas-source-refresh
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Collect evidence candidates
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/collect_atlas_candidates.py
+      - name: Validate atlas JSON
+        run: |
+          python scripts/collect_atlas_candidates.py --validate-only
+          python -m json.tool .atlas/candidate_inbox.json >/dev/null
+          for file in markets/data/*/*.json markets/sources.json; do python -m json.tool "$file" >/dev/null; done
+      - name: Open or update review PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- .atlas/candidate_inbox.json; then
+            echo "No candidate changes"
+            exit 0
+          fi
+          branch="automation/atlas-source-refresh"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add .atlas/candidate_inbox.json
+          git commit -m "Refresh atlas evidence candidates"
+          git push --force-with-lease origin "$branch"
+          if ! gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr create --base master --head "$branch" --title "Review weekly atlas evidence candidates" --body "Automated evidence inbox only. Review sources and claims before changing any public atlas dataset. X/social evidence is never sufficient on its own."
+          fi

--- a/markets/SOURCES.md
+++ b/markets/SOURCES.md
@@ -1,0 +1,26 @@
+# Markets atlas sourcing
+
+The atlas is a reviewed market map, not a live news feed. Automated collectors write only to `.atlas/candidate_inbox.json`; that file is not loaded by the site.
+
+## Evidence hierarchy
+
+1. Primary institutional evidence: regulators, exchange rulebooks, official product documentation, filings, and release notes.
+2. Research evidence: papers and working papers discovered through durable indexes, then checked at the publisher or repository.
+3. Commercial evidence: official funding, acquisition, partnership, customer, and product announcements.
+4. Usage evidence: repository activity, package adoption, volumes, and benchmark use.
+5. Discovery leads: curated X accounts, newsletters, and publications. These can suggest a question but cannot establish a public claim alone.
+
+## Promotion contract
+
+Every new or materially changed public claim should include:
+
+- a source URL;
+- the date the source was observed;
+- a source class;
+- whether the source is primary or corroborating;
+- the specific atlas implication;
+- a confidence assessment when interpretation is involved.
+
+Entity facts should be supported by primary evidence. Literature signals should link to the paper. Market-structure scores and unbuilt opportunities require at least one primary or research source plus an explicit explanation of the inference.
+
+The source registry is [`sources.json`](sources.json). It defines collection endpoints, product lanes, authority, and promotion policy. The Monday workflow opens or updates a review PR; publication remains a separate decision.

--- a/markets/sources.json
+++ b/markets/sources.json
@@ -1,0 +1,100 @@
+{
+  "version": 1,
+  "policy": {
+    "publication_rule": "Collectors create evidence candidates only. Public atlas claims require review and a separate commit.",
+    "x_rule": "X is discovery-only and may not establish or update an atlas claim without a primary or research source.",
+    "freshness_days": 14,
+    "max_candidates_per_source": 8
+  },
+  "lanes": {
+    "ai": {
+      "keywords": ["inference", "serving", "on-device", "edge ai", "edge device", "local model", "quantization", "agent", "evaluation", "benchmark", "retrieval", "model context protocol", "llama.cpp"],
+      "targets": ["entries", "literature", "market_structure", "unbuilt"]
+    },
+    "finance": {
+      "keywords": ["prediction market", "event contract", "market structure", "market microstructure", "clearing", "settlement", "exchange", "derivative", "arbitrage", "benchmark", "market data", "collateral", "liquidity"],
+      "targets": ["entries", "literature", "market_structure", "unbuilt"]
+    }
+  },
+  "sources": [
+    {
+      "id": "openalex-ai",
+      "name": "OpenAlex: AI systems research",
+      "lane": "ai",
+      "kind": "openalex",
+      "source_class": "research_index",
+      "authority": "research",
+      "promotion_policy": "corroborate",
+      "endpoint": "https://api.openalex.org/works",
+      "query": "machine learning inference serving agents evaluation on-device",
+      "homepage": "https://openalex.org"
+    },
+    {
+      "id": "openalex-finance",
+      "name": "OpenAlex: market design research",
+      "lane": "finance",
+      "kind": "openalex",
+      "source_class": "research_index",
+      "authority": "research",
+      "promotion_policy": "corroborate",
+      "endpoint": "https://api.openalex.org/works",
+      "query": "prediction markets market microstructure clearing settlement market design",
+      "homepage": "https://openalex.org"
+    },
+    {
+      "id": "sec-press-releases",
+      "name": "U.S. Securities and Exchange Commission",
+      "lane": "finance",
+      "kind": "feed",
+      "source_class": "regulator",
+      "authority": "primary",
+      "promotion_policy": "eligible",
+      "endpoint": "https://www.sec.gov/news/pressreleases.rss",
+      "homepage": "https://www.sec.gov/newsroom/press-releases"
+    },
+    {
+      "id": "cftc-press-releases",
+      "name": "Commodity Futures Trading Commission",
+      "lane": "finance",
+      "kind": "feed",
+      "source_class": "regulator",
+      "authority": "primary",
+      "promotion_policy": "eligible",
+      "endpoint": "https://www.cftc.gov/RSS/RSSGP/rssgp.xml",
+      "homepage": "https://www.cftc.gov/RSS/index.htm"
+    },
+    {
+      "id": "github-llama-cpp",
+      "name": "llama.cpp releases",
+      "lane": "ai",
+      "kind": "github_releases",
+      "source_class": "official_product",
+      "authority": "primary",
+      "promotion_policy": "eligible",
+      "endpoint": "https://api.github.com/repos/ggml-org/llama.cpp/releases",
+      "homepage": "https://github.com/ggml-org/llama.cpp"
+    },
+    {
+      "id": "github-onnx-runtime",
+      "name": "ONNX Runtime releases",
+      "lane": "ai",
+      "kind": "github_releases",
+      "source_class": "official_product",
+      "authority": "primary",
+      "promotion_policy": "eligible",
+      "endpoint": "https://api.github.com/repos/microsoft/onnxruntime/releases",
+      "homepage": "https://github.com/microsoft/onnxruntime"
+    },
+    {
+      "id": "x-curated-portfolios",
+      "name": "Curated X account portfolios",
+      "lane": "ai,finance",
+      "kind": "external_discovery",
+      "source_class": "social",
+      "authority": "lead_only",
+      "promotion_policy": "discovery_only",
+      "endpoint": "https://operator.octomil.com/forge",
+      "homepage": "https://operator.octomil.com/forge"
+    }
+  ]
+}

--- a/scripts/collect_atlas_candidates.py
+++ b/scripts/collect_atlas_candidates.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Collect review candidates without modifying public atlas claims."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "markets" / "sources.json"
+INBOX_PATH = ROOT / ".atlas" / "candidate_inbox.json"
+USER_AGENT = "sbangalore-markets-atlas/1.0 (https://sbangalore.github.io/markets/)"
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _get(url: str, *, accept: str = "application/json") -> bytes:
+    headers = {"User-Agent": USER_AGENT, "Accept": accept}
+    if "api.github.com" in url and os.getenv("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {os.environ['GITHUB_TOKEN']}"
+        headers["X-GitHub-Api-Version"] = "2022-11-28"
+    with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=30) as response:
+        return response.read()
+
+
+def _date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        try:
+            from email.utils import parsedate_to_datetime
+            return parsedate_to_datetime(value).astimezone(timezone.utc)
+        except (TypeError, ValueError):
+            return None
+
+
+def _feed_items(source: dict[str, Any]) -> list[dict[str, Any]]:
+    document = _get(source["endpoint"], accept="application/rss+xml, application/atom+xml, application/xml").decode("utf-8", "replace")
+    rows: list[dict[str, Any]] = []
+    for item in re.findall(r"<item\b[^>]*>(.*?)</item>", document, flags=re.I | re.S):
+        def value(tag: str) -> str:
+            match = re.search(rf"<{tag}\b[^>]*>(.*?)</{tag}>", item, flags=re.I | re.S)
+            if not match:
+                return ""
+            text = re.sub(r"<!\[CDATA\[(.*?)\]\]>", r"\1", match.group(1), flags=re.S)
+            return html.unescape(re.sub(r"<[^>]+>", " ", text)).strip()
+        rows.append({
+            "title": value("title"),
+            "url": value("link"),
+            "published_at": value("pubDate"),
+            "summary": value("description"),
+        })
+    return rows
+
+
+def _openalex_items(source: dict[str, Any], since: datetime) -> list[dict[str, Any]]:
+    params = {
+        "search": source["query"],
+        "filter": f"from_publication_date:{since.date().isoformat()},is_retracted:false",
+        "sort": "publication_date:desc",
+        "per-page": "25",
+        "select": "id,display_name,publication_date,doi,primary_location,authorships,topics",
+    }
+    body = json.loads(_get(source["endpoint"] + "?" + urllib.parse.urlencode(params)))
+    rows = []
+    for item in body.get("results", []):
+        location = item.get("primary_location") or {}
+        rows.append({
+            "title": item.get("display_name") or "",
+            "url": item.get("doi") or location.get("landing_page_url") or item.get("id") or "",
+            "published_at": item.get("publication_date") or "",
+            "summary": " ".join(topic.get("display_name", "") for topic in item.get("topics", [])[:5]),
+            "authors": [a.get("author", {}).get("display_name") for a in item.get("authorships", [])[:5] if a.get("author")],
+        })
+    return rows
+
+
+def _github_items(source: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for item in json.loads(_get(source["endpoint"] + "?per_page=20")):
+        if item.get("draft") or item.get("prerelease"):
+            continue
+        if re.fullmatch(r"b\d+", str(item.get("name") or item.get("tag_name") or ""), flags=re.I):
+            continue
+        rows.append({
+            "title": item.get("name") or item.get("tag_name") or "Release",
+            "url": item.get("html_url") or "",
+            "published_at": item.get("published_at") or "",
+            "summary": (item.get("body") or "")[:2000],
+        })
+    return rows
+
+
+def validate_registry(registry: dict[str, Any]) -> None:
+    required = {"id", "name", "lane", "kind", "source_class", "authority", "promotion_policy", "endpoint", "homepage"}
+    ids: set[str] = set()
+    for source in registry.get("sources", []):
+        missing = required - source.keys()
+        if missing:
+            raise ValueError(f"{source.get('id', 'source')} missing: {sorted(missing)}")
+        if source["id"] in ids:
+            raise ValueError(f"duplicate source id: {source['id']}")
+        ids.add(source["id"])
+        if source["promotion_policy"] == "discovery_only" and source["authority"] != "lead_only":
+            raise ValueError(f"{source['id']} discovery-only sources must be lead-only")
+
+
+def collect(registry: dict[str, Any], now: datetime) -> dict[str, Any]:
+    policy = registry["policy"]
+    since = now - timedelta(days=int(policy["freshness_days"]))
+    candidates: list[dict[str, Any]] = []
+    source_runs: list[dict[str, Any]] = []
+    for source in registry["sources"]:
+        if source["kind"] == "external_discovery":
+            source_runs.append({"source_id": source["id"], "status": "external", "candidate_count": 0})
+            continue
+        try:
+            if source["kind"] == "feed":
+                rows = _feed_items(source)
+            elif source["kind"] == "openalex":
+                rows = _openalex_items(source, since)
+            elif source["kind"] == "github_releases":
+                rows = _github_items(source)
+            else:
+                raise ValueError(f"unsupported source kind: {source['kind']}")
+            lane = registry["lanes"][source["lane"]]
+            accepted = []
+            for row in rows:
+                published = _date(row.get("published_at"))
+                if published and published < since:
+                    continue
+                haystack = row.get("title", "") if source["kind"] == "feed" else f"{row.get('title', '')} {row.get('summary', '')}"
+                haystack = haystack.lower()
+                matches = [term for term in lane["keywords"] if term.lower() in haystack]
+                minimum_matches = 2 if source["source_class"] == "research_index" else 1
+                if len(matches) < minimum_matches:
+                    continue
+                url = row.get("url") or source["homepage"]
+                key = hashlib.sha256(f"{source['id']}|{url}|{row.get('title', '')}".encode()).hexdigest()[:16]
+                accepted.append({
+                    "candidate_id": f"atlas-{key}",
+                    "lane": source["lane"],
+                    "title": row.get("title", "").strip(),
+                    "url": url,
+                    "published_at": published.isoformat() if published else None,
+                    "source_id": source["id"],
+                    "source_name": source["name"],
+                    "source_class": source["source_class"],
+                    "authority": source["authority"],
+                    "promotion_policy": source["promotion_policy"],
+                    "matched_terms": matches,
+                    "proposed_targets": lane["targets"],
+                    "review_status": "unreviewed",
+                })
+            limit = int(policy["max_candidates_per_source"])
+            candidates.extend(accepted[:limit])
+            source_runs.append({"source_id": source["id"], "status": "ok", "candidate_count": min(len(accepted), limit)})
+        except Exception as exc:  # one source must not suppress the full inbox
+            source_runs.append({"source_id": source["id"], "status": "error", "candidate_count": 0, "error": f"{type(exc).__name__}: {exc}"[:240]})
+    candidates.sort(key=lambda item: (item.get("published_at") or "", item["authority"] == "primary"), reverse=True)
+    return {
+        "schema_version": 1,
+        "generated_at": now.isoformat(),
+        "publication_rule": policy["publication_rule"],
+        "candidate_count": len(candidates),
+        "source_runs": source_runs,
+        "candidates": candidates,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    registry = _read_json(REGISTRY_PATH)
+    validate_registry(registry)
+    if args.validate_only:
+        print(f"validated {len(registry['sources'])} atlas sources")
+        return 0
+    inbox = collect(registry, datetime.now(timezone.utc))
+    if args.dry_run:
+        print(json.dumps(inbox, indent=2, sort_keys=True))
+        return 0
+    INBOX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    INBOX_PATH.write_text(json.dumps(inbox, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {inbox['candidate_count']} candidates to {INBOX_PATH.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed
- adds a versioned source registry for the AI and finance atlas lanes
- adds a deterministic collector for OpenAlex, SEC/CFTC feeds, official GitHub releases, and the external curated-X discovery surface
- writes candidates to a non-public review inbox instead of changing atlas claims
- adds a weekly workflow that opens or updates an evidence-review PR
- documents evidence hierarchy and promotion requirements

## Product guardrails
- X/social sources are discovery-only
- papers discovered through an index require review at the underlying source
- automated collection cannot edit entities, scores, literature, or unbuilt opportunities
- noisy sources are filtered by lane-specific term thresholds and per-source caps

## Initial pass
The live collector returned two focused AI-infrastructure papers. Generic SEC mentions, broad agent/evaluation papers, and automated llama.cpp build tags were rejected.

## Validation
- source registry validation and live collection
- all atlas JSON and workflow YAML parsed successfully
- Python compile check
- `git diff --check`
