### PR TITLE
Open atlas evidence reviews as drafts

### DIFF
--- a/.github/workflows/atlas-source-refresh.yml
+++ b/.github/workflows/atlas-source-refresh.yml
@@ -48,5 +48,5 @@ jobs:
           git commit -m "Refresh atlas evidence candidates"
           git push --force-with-lease origin "$branch"
           if ! gh pr view "$branch" >/dev/null 2>&1; then
-            gh pr create --base master --head "$branch" --title "Review weekly atlas evidence candidates" --body "Automated evidence inbox only. Review sources and claims before changing any public atlas dataset. X/social evidence is never sufficient on its own."
+            gh pr create --draft --base master --head "$branch" --title "Review weekly atlas evidence candidates" --body "Automated evidence inbox only. Review sources and claims before changing any public atlas dataset. X/social evidence is never sufficient on its own."
           fi


### PR DESCRIPTION
Keeps automated evidence inbox updates explicitly non-approved until a reviewer promotes supported claims in a separate change.